### PR TITLE
Uncomment previously failing Transformations unit tests

### DIFF
--- a/utest/ui/Transformations.cpp
+++ b/utest/ui/Transformations.cpp
@@ -258,46 +258,45 @@ TEST(Transformation, ComputeRigidTransformDataPoints2D)
     }
 }
 
-//// (CRITICAL) ToDo: investigate unit-test failure (ref task NMO-301)
-//TEST(Transformation, ComputeRigidTransformDataPoints3D)
-//{
-//    std::shared_ptr<PM::Transformation> transformator = PM::get().REG(Transformation).create("RigidTransformation");
-//
-//    // Identity.
-//    {
-//        const Eigen::Matrix<NumericType, 3, 1> translation{ 0, 0, 0 };
-//        const Eigen::Quaternion<NumericType> rotation{ 1, 0, 0, 0 };
-//        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation);
-//        // Transform and assert on the result.
-//        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator);
-//    }
-//
-//    // Pure translation.
-//    {
-//        const Eigen::Matrix<NumericType, 3, 1> translation{ -1.0001, 5, -12321.234 };
-//        const Eigen::Quaternion<NumericType> rotation{ 1, 0, 0, 0 };
-//        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation);
-//        // Transform and assert on the result.
-//        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator);
-//    }
-//    // Pure rotation.
-//    {
-//        const Eigen::Matrix<NumericType, 3, 1> translation{ 0, 0, 0 };
-//        const Eigen::Quaternion<NumericType> rotation{ 1, -5, 23, 0.5 };
-//        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation);
-//        // Transform and assert on the result.
-//        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator);
-//    }
-//    // Translation + rotation.
-//    {
-//        const NumericType kEpsilonNumericalError = 1e-6;
-//        const Eigen::Matrix<NumericType, 3, 1> translation{ 1, -3, -4 };
-//        const Eigen::Quaternion<NumericType> rotation{ 0, -2.54, 0, 0.5 };
-//        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation);
-//        // Transform and assert on the result.
-//        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator, kEpsilonNumericalError);
-//    }
-//}
+TEST(Transformation, ComputeRigidTransformDataPoints3D)
+{
+    std::shared_ptr<PM::Transformation> transformator = PM::get().REG(Transformation).create("RigidTransformation");
+
+    // Identity.
+    {
+        const Eigen::Matrix<NumericType, 3, 1> translation{ 0, 0, 0 };
+        const Eigen::Quaternion<NumericType> rotation{ 1, 0, 0, 0 };
+        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation);
+        // Transform and assert on the result.
+        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator);
+    }
+
+    // Pure translation.
+    {
+        const Eigen::Matrix<NumericType, 3, 1> translation{ -1.0001, 5, -12321.234 };
+        const Eigen::Quaternion<NumericType> rotation{ 1, 0, 0, 0 };
+        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation);
+        // Transform and assert on the result.
+        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator);
+    }
+    // Pure rotation.
+    {
+        const Eigen::Matrix<NumericType, 3, 1> translation{ 0, 0, 0 };
+        const Eigen::Quaternion<NumericType> rotation{ 1, -5, 23, 0.5 };
+        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation);
+        // Transform and assert on the result.
+        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator);
+    }
+    // Translation + rotation.
+    {
+        const NumericType kEpsilonNumericalError = 1e-6;
+        const Eigen::Matrix<NumericType, 3, 1> translation{ 1, -3, -4 };
+        const Eigen::Quaternion<NumericType> rotation{ 0, -2.54, 0, 0.5 };
+        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation);
+        // Transform and assert on the result.
+        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator, kEpsilonNumericalError);
+    }
+}
 
 TEST(Transformation, ComputeSimilarityTransformDataPoints2D)
 {
@@ -359,64 +358,63 @@ TEST(Transformation, ComputeSimilarityTransformDataPoints2D)
     }
 }
 
-//// (CRITICAL) ToDo: investigate unit-test failure (ref task NMO-301)
-//TEST(Transformation, ComputeSimilarityTransformDataPoints3D)
-//{
-//    std::shared_ptr<PM::Transformation> transformator = PM::get().REG(Transformation).create("SimilarityTransformation");
-//
-//    // Identity.
-//    {
-//        const Eigen::Matrix<NumericType, 3, 1> translation{ 0, 0, 0 };
-//        const Eigen::Quaternion<NumericType> rotation{ 1, 0, 0, 0 };
-//        const NumericType scale{ 1.0 };
-//        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation, scale);
-//        // Transform and assert on the result.
-//        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator);
-//    }
-//    // Pure Upscaling.
-//    {
-//        const Eigen::Matrix<NumericType, 3, 1> translation{ 0, 0, 0 };
-//        const Eigen::Quaternion<NumericType> rotation{ 1, 0, 0, 0 };
-//        const NumericType scale{ 5.0 };
-//        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation, scale);
-//        // Transform and assert on the result.
-//        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator);
-//    }
-//    // Pure Downscaling.
-//    {
-//        const Eigen::Matrix<NumericType, 3, 1> translation{ 0, 0, 0 };
-//        const Eigen::Quaternion<NumericType> rotation{ 1, 0, 0, 0 };
-//        const NumericType scale{ 0.1 };
-//        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation, scale);
-//        // Transform and assert on the result.
-//        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator);
-//    }
-//    // Pure translation + Downscaling.
-//    {
-//        const Eigen::Matrix<NumericType, 3, 1> translation{ -1.0001, 5, -12321.234 };
-//        const Eigen::Quaternion<NumericType> rotation{ 1, 0, 0, 0 };
-//        const NumericType scale{ 0.5 };
-//        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation, scale);
-//        // Transform and assert on the result.
-//        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator);
-//    }
-//    // Pure rotation + Upscaling.
-//    {
-//        const Eigen::Matrix<NumericType, 3, 1> translation{ 0, 0, 0 };
-//        const Eigen::Quaternion<NumericType> rotation{ 1, -5, 23, 0.5 };
-//        const NumericType scale{ 1.9 };
-//        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation, scale);
-//        // Transform and assert on the result.
-//        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator);
-//    }
-//    // Translation + rotation + Upscaling.
-//    {
-//        const NumericType kEpsilonNumericalError = 1e-6;
-//        const Eigen::Matrix<NumericType, 3, 1> translation{ 1, -3, -4 };
-//        const Eigen::Quaternion<NumericType> rotation{ 0, -2.54, 0, 0.5 };
-//        const NumericType scale{ 1.9 };
-//        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation, scale);
-//        // Transform and assert on the result.
-//        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator, kEpsilonNumericalError);
-//    }
-//}
+TEST(Transformation, ComputeSimilarityTransformDataPoints3D)
+{
+    std::shared_ptr<PM::Transformation> transformator = PM::get().REG(Transformation).create("SimilarityTransformation");
+
+    // Identity.
+    {
+        const Eigen::Matrix<NumericType, 3, 1> translation{ 0, 0, 0 };
+        const Eigen::Quaternion<NumericType> rotation{ 1, 0, 0, 0 };
+        const NumericType scale{ 1.0 };
+        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation, scale);
+        // Transform and assert on the result.
+        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator);
+    }
+    // Pure Upscaling.
+    {
+        const Eigen::Matrix<NumericType, 3, 1> translation{ 0, 0, 0 };
+        const Eigen::Quaternion<NumericType> rotation{ 1, 0, 0, 0 };
+        const NumericType scale{ 5.0 };
+        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation, scale);
+        // Transform and assert on the result.
+        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator);
+    }
+    // Pure Downscaling.
+    {
+        const Eigen::Matrix<NumericType, 3, 1> translation{ 0, 0, 0 };
+        const Eigen::Quaternion<NumericType> rotation{ 1, 0, 0, 0 };
+        const NumericType scale{ 0.1 };
+        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation, scale);
+        // Transform and assert on the result.
+        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator);
+    }
+    // Pure translation + Downscaling.
+    {
+        const Eigen::Matrix<NumericType, 3, 1> translation{ -1.0001, 5, -12321.234 };
+        const Eigen::Quaternion<NumericType> rotation{ 1, 0, 0, 0 };
+        const NumericType scale{ 0.5 };
+        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation, scale);
+        // Transform and assert on the result.
+        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator);
+    }
+    // Pure rotation + Upscaling.
+    {
+        const Eigen::Matrix<NumericType, 3, 1> translation{ 0, 0, 0 };
+        const Eigen::Quaternion<NumericType> rotation{ 1, -5, 23, 0.5 };
+        const NumericType scale{ 1.9 };
+        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation, scale);
+        // Transform and assert on the result.
+        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator);
+    }
+    // Translation + rotation + Upscaling.
+    {
+        const NumericType kEpsilonNumericalError = 1e-6;
+        const Eigen::Matrix<NumericType, 3, 1> translation{ 1, -3, -4 };
+        const Eigen::Quaternion<NumericType> rotation{ 0, -2.54, 0, 0.5 };
+        const NumericType scale{ 1.9 };
+        const Eigen::Transform<NumericType, 3, Eigen::Affine> transformation = buildUpTransformation3D(translation, rotation, scale);
+        // Transform and assert on the result.
+        assertOnDataPointsTransformation(data3D, transformation.matrix(), transformator, kEpsilonNumericalError);
+    }
+}


### PR DESCRIPTION
The commented Transformations unit tests seem not to be failing anymore so I put them back to work.