### PR TITLE
New DataPoints filter for descriptor augmentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,7 @@ set(POINTMATCHER_SRC
 	pointmatcher/ErrorMinimizers/PointToPointSimilarity.cpp
 	pointmatcher/ErrorMinimizers/Identity.cpp
 #DataPointsFilters
+	pointmatcher/DataPointsFilters/AddDescriptor.cpp
 	pointmatcher/DataPointsFilters/Identity.cpp
 	pointmatcher/DataPointsFilters/RemoveNaN.cpp
 	pointmatcher/DataPointsFilters/MaxDist.cpp

--- a/doc/DataFilters.md
+++ b/doc/DataFilters.md
@@ -51,19 +51,21 @@ Note that *datapoint filters* differ from *outlier filters* which appear further
 
 ### Descriptor Augmenting
 
-1. [Observation Direction Filter](#obsdirectionhead)
+1. [Add Descriptor Filter](#adddescriptorhead)
 
-2. [Surface Normal Filter](#surfacenormalhead)
+2. [Observation Direction Filter](#obsdirectionhead)
 
-3. [Orient Normals Filter](#orientnormalshead)
+3. [Surface Normal Filter](#surfacenormalhead)
 
-4. [Sampling Surface Normal Filter](#samplingnormhead)
+4. [Orient Normals Filter](#orientnormalshead)
 
-5. [Simple Sensor Noise Filter](#sensornoisehead)
+5. [Sampling Surface Normal Filter](#samplingnormhead)
 
-6. [Saliency Filter](#saliencyhead)
+6. [Simple Sensor Noise Filter](#sensornoisehead)
 
-7. [Fixed Step Sampling Filter](#fixedstepsamplinghead)
+7. [Saliency Filter](#saliencyhead)
+
+8. [Fixed Step Sampling Filter](#fixedstepsamplinghead)
 
 
 ## An Example Point Cloud View of an Appartment
@@ -73,6 +75,25 @@ Note that *datapoint filters* differ from *outlier filters* which appear further
 The following examples are drawn from the apartment dataset available for [download](http://projects.asl.ethz.ch/datasets/doku.php?id=laserregistration:apartment:home) from the ASL at ETH Zurich.  A top-down view of the point cloud is depicted below, with the colors showing vertical elevation.  The ceiling has been removed from the point cloud such that the floor (in blue) and the walls (in red) are clearly visible.  Note that the coordinate origin is placed in the kitchen at the starting point of data capture, which is in the top-left of the top-down view and floor plan.
 
 ![alt text](images/appt_top.png "Top down view of point cloud from appartment dataset")
+
+## Add Descriptor Filter <a name="adddescriptorhead"></a>
+
+### Description
+
+Adds a new descriptor to an existing point cloud or overwrites existing descriptor with the same name.
+
+__Required descriptors:__ none   
+__Output descriptor:__ User defined.  
+__Sensor assumed to be at the origin:__ no  
+__Impact on the number of points:__ none   
+__Altered descriptors:__  Existing descriptor with name equal to `descriptorName`.  
+__Altered features:__     none.;
+
+| Parameter           | Description                                                                                                                                          | Default value | Allowable range |
+|---------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|:--------------|:----------------|
+| descriptorName      | Name of the descriptor to be added.                                                                                                                  |               |                 |
+| descriptorDimension | Length of the descriptor to be added.                                                                                                                | 1             | 1 to 4294967295 |
+| descriptorValues    | Values of the descriptor to be added. List of 'descriptorDimension' numbers of type T, separated by commas, closed in brackets, e.g. [2.2, 3.0, 6.1] |               |                 |
 
 ## Bounding Box Filter <a name="boundingboxhead"></a>
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,6 +22,3 @@ target_link_libraries(icp_advance_api pointmatcher)
 
 add_executable(icp_customized icp_customized.cpp)
 target_link_libraries(icp_customized pointmatcher)
-
-add_executable(add_descriptor_debug addDescriptorDebug.cpp)
-target_link_libraries(add_descriptor_debug pointmatcher)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,3 +22,6 @@ target_link_libraries(icp_advance_api pointmatcher)
 
 add_executable(icp_customized icp_customized.cpp)
 target_link_libraries(icp_customized pointmatcher)
+
+add_executable(add_descriptor_debug addDescriptorDebug.cpp)
+target_link_libraries(add_descriptor_debug pointmatcher)

--- a/examples/data/add_descriptor_config.yaml
+++ b/examples/data/add_descriptor_config.yaml
@@ -1,0 +1,4 @@
+- AddDescriptorDataPointsFilter:
+        descriptorName: deviation
+        descriptorDimension: 9
+        descriptorValues: [0.0009, 0, 0, 0, 0.0009, 0, 0, 0, 0.0009]

--- a/pointmatcher/DataPointsFilters/AddDescriptor.cpp
+++ b/pointmatcher/DataPointsFilters/AddDescriptor.cpp
@@ -27,14 +27,32 @@ typename PointMatcher<T>::DataPoints AddDescriptorDataPointsFilter<T>::filter(
 // In-place filter
 template<typename T>
 void AddDescriptorDataPointsFilter<T>::inPlaceFilter(
-	DataPoints& cloud)
+        DataPoints& cloud)
 {
     Matrix matrix = PM::Matrix::Ones(descriptorDimension, cloud.getNbPoints());
     for(std::size_t i = 0; i < descriptorDimension; ++i)
     {
         matrix.row(i) *= descriptorValues[i];
     }
-    cloud.addDescriptor(descriptorName, matrix);
+    if(!cloud.descriptorExists(descriptorName))
+    {
+        cloud.addDescriptor(descriptorName, matrix);
+    }
+    else
+    {
+        if(descriptorDimension == cloud.getDescriptorDimension(descriptorName))
+        {
+            cloud.getDescriptorViewByName(descriptorName) = matrix;
+        }
+        else
+        {
+            // FIXME deal with overwriting descriptors that have different dimensions
+            throw std::runtime_error("Can't overwrite existing descriptor " + descriptorName + " with dimension " +
+                                     std::to_string(cloud.getDescriptorDimension(descriptorName)) +
+                                     " by a new descriptor with dimension " +
+                                     std::to_string(descriptorDimension) + ".");
+        }
+    }
 
 }
 

--- a/pointmatcher/DataPointsFilters/AddDescriptor.cpp
+++ b/pointmatcher/DataPointsFilters/AddDescriptor.cpp
@@ -1,0 +1,42 @@
+// kate: replace-tabs off; indent-width 4; indent-mode normal
+// vim: ts=4:sw=4:noexpandtab
+
+#include "AddDescriptor.h"
+
+template <typename T>
+AddDescriptorDataPointsFilter<T>::AddDescriptorDataPointsFilter(const Parameters& params) :
+	PointMatcher<T>::DataPointsFilter("AddDescriptorDataPointsFilter",
+		AddDescriptorDataPointsFilter::availableParameters(), params),
+	descriptorName(Parametrizable::get<std::string>("descriptorName")),
+	descriptorDimension(Parametrizable::get<std::size_t>("descriptorDimension")),
+	descriptorValues(Parametrizable::getVector<T>("descriptorValues"))
+{
+    assert(descriptorDimension == descriptorValues.size());
+}
+
+// AddDescriptorDataPointsFilter
+template<typename T>
+typename PointMatcher<T>::DataPoints AddDescriptorDataPointsFilter<T>::filter(
+	const DataPoints& input)
+{
+	DataPoints output(input);
+	inPlaceFilter(output);
+	return output;
+}
+
+// In-place filter
+template<typename T>
+void AddDescriptorDataPointsFilter<T>::inPlaceFilter(
+	DataPoints& cloud)
+{
+    Matrix matrix = PM::Matrix::Ones(descriptorDimension, cloud.getNbPoints());
+    for(std::size_t i = 0; i < descriptorDimension; ++i)
+    {
+        matrix.row(i) *= descriptorValues[i];
+    }
+    cloud.addDescriptor(descriptorName, matrix);
+
+}
+
+template struct AddDescriptorDataPointsFilter<float>;
+template struct AddDescriptorDataPointsFilter<double>;

--- a/pointmatcher/DataPointsFilters/AddDescriptor.h
+++ b/pointmatcher/DataPointsFilters/AddDescriptor.h
@@ -31,7 +31,7 @@ struct AddDescriptorDataPointsFilter : public PointMatcher<T>::DataPointsFilter
 
     inline static const std::string description()
     {
-        return "Adds a new descriptor to an existing point cloud.\n\n"
+        return "Adds a new descriptor to an existing point cloud or overwrites existing descriptor with the same name.\n\n"
 			   "Required descriptors: none.\n"
 		       "Produced descriptors:  User defined.\n"
 			   "Altered descriptors:  none.\n"

--- a/pointmatcher/DataPointsFilters/AddDescriptor.h
+++ b/pointmatcher/DataPointsFilters/AddDescriptor.h
@@ -1,0 +1,57 @@
+// kate: replace-tabs off; indent-width 4; indent-mode normal
+// vim: ts=4:sw=4:noexpandtab
+
+#pragma once
+
+#include "PointMatcher.h"
+
+//! Add new descriptor to an existing point cloud
+template<typename T>
+struct AddDescriptorDataPointsFilter : public PointMatcher<T>::DataPointsFilter
+{
+    // Type definitions
+    typedef PointMatcher<T> PM;
+    typedef typename PM::DataPoints DataPoints;
+    typedef typename PM::DataPointsFilter DataPointsFilter;
+
+    typedef PointMatcherSupport::Parametrizable Parametrizable;
+    typedef PointMatcherSupport::Parametrizable P;
+    typedef Parametrizable::Parameters Parameters;
+    typedef Parametrizable::ParameterDoc ParameterDoc;
+    typedef Parametrizable::ParametersDoc ParametersDoc;
+    typedef Parametrizable::InvalidParameter InvalidParameter;
+
+    typedef typename PointMatcher<T>::Matrix Matrix;
+    typedef typename PointMatcher<T>::Vector Vector;
+    typedef typename PointMatcher<T>::DataPoints::InvalidField InvalidField;
+
+    const std::string descriptorName;
+    const std::size_t descriptorDimension;
+    const std::vector<T> descriptorValues;
+
+    inline static const std::string description()
+    {
+        return "Adds a new descriptor to an existing point cloud.\n\n"
+			   "Required descriptors: none.\n"
+		       "Produced descriptors:  User defined.\n"
+			   "Altered descriptors:  none.\n"
+			   "Altered features:     none.";
+    }
+
+    inline static const ParametersDoc availableParameters()
+    {
+        return {
+                {"descriptorName",      "Name of the descriptor to be added.", "testDescriptor" },
+                {"descriptorDimension", "Length of the descriptor to be added.", "1",            "1", "4294967295", &P::Comp < std::size_t > },
+                {"descriptorValues",    "Values of the descriptor to be added.\n"
+                                        "List of 'descriptorDimension' numbers of type T, separated by commas, closed in brackets,\n"
+                                        "e.g. [2.2, 3.0, 6.1]", ""}
+        };
+    }
+
+	//Constructor, uses parameter interface
+	explicit AddDescriptorDataPointsFilter(const Parameters& params = Parameters());
+
+    virtual DataPoints filter(const DataPoints& input);
+    virtual void inPlaceFilter(DataPoints& cloud);
+};

--- a/pointmatcher/DataPointsFiltersImpl.h
+++ b/pointmatcher/DataPointsFiltersImpl.h
@@ -36,6 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef __POINTMATCHER_DATAPOINTSFILTERS_H
 #define __POINTMATCHER_DATAPOINTSFILTERS_H
 
+#include "DataPointsFilters/AddDescriptor.h"
 #include "DataPointsFilters/Identity.h"
 #include "DataPointsFilters/RemoveNaN.h"
 #include "DataPointsFilters/MaxDist.h"
@@ -70,6 +71,7 @@ template<typename T>
 struct DataPointsFiltersImpl
 {
 	typedef ::IdentityDataPointsFilter<T>   IdentityDataPointsFilter;
+	typedef ::AddDescriptorDataPointsFilter<T>   AddDescriptorDataPointsFilter;
 	typedef ::RemoveNaNDataPointsFilter<T>  RemoveNaNDataPointsFilter;
 	typedef ::MaxDistDataPointsFilter<T>	MaxDistDataPointsFilter;
 	typedef ::MinDistDataPointsFilter<T>	MinDistDataPointsFilter;

--- a/pointmatcher/Registrar.cpp
+++ b/pointmatcher/Registrar.cpp
@@ -19,8 +19,21 @@ namespace PointMatcherSupport
 			for(YAML::const_iterator paramIt = mapIt->second.begin(); paramIt != mapIt->second.end(); ++paramIt)
 			{
 				std::string key = paramIt->first.as<std::string>();
-				std::string value = paramIt->second.as<std::string>();
-				params[key] = value;
+                if (paramIt->second.IsSequence())
+                {
+                    std::ostringstream oss;
+                    oss << "[";
+                    for(int i = 0; i < paramIt->second.size()-1; ++i)
+                    {
+                        oss << paramIt->second[i] << ", ";
+                    }
+                    oss << paramIt->second[paramIt->second.size()-1] << "]";
+                    params[key] = oss.str();
+                }
+                else
+                {
+                    params[key] = paramIt->second.as<std::string>();
+                }
 			}
 		}
 	}

--- a/pointmatcher/Registrar.h
+++ b/pointmatcher/Registrar.h
@@ -113,7 +113,7 @@ namespace PointMatcherSupport
 			{
 				for (const auto& param : params)
 					throw Parametrizable::InvalidParameter(
-							(boost::format("Parameter %1% was set but module %2% dos not use any parameter") % param.first % className).str()
+							(boost::format("Parameter %1% was set but module %2% does not use any parameter") % param.first % className).str()
 						);
 
 				return std::make_shared<C>();

--- a/pointmatcher/Registry.cpp
+++ b/pointmatcher/Registry.cpp
@@ -64,6 +64,7 @@ PointMatcher<T>::PointMatcher()
 	ADD_TO_REGISTRAR_NO_PARAM(Transformation, PureTranslation, typename TransformationsImpl<T>::PureTranslation)
 	ADD_TO_REGISTRAR_NO_PARAM(Transformation, SimilarityTransformation, typename TransformationsImpl<T>::SimilarityTransformation)	
 	
+	ADD_TO_REGISTRAR(DataPointsFilter, AddDescriptorDataPointsFilter, typename DataPointsFiltersImpl<T>::AddDescriptorDataPointsFilter)
 	ADD_TO_REGISTRAR_NO_PARAM(DataPointsFilter, IdentityDataPointsFilter, typename DataPointsFiltersImpl<T>::IdentityDataPointsFilter)
 	ADD_TO_REGISTRAR_NO_PARAM(DataPointsFilter, RemoveNaNDataPointsFilter, typename DataPointsFiltersImpl<T>::RemoveNaNDataPointsFilter)
 	ADD_TO_REGISTRAR(DataPointsFilter, MaxDistDataPointsFilter, typename DataPointsFiltersImpl<T>::MaxDistDataPointsFilter)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -49,6 +49,7 @@ set(PYBIND11_SOURCES
     errorminimizers/point_to_point_with_cov.cpp
 
     #datapointfilters module
+    datapointsfilters/add_descriptor.cpp
     datapointsfilters/bounding_box.cpp
     datapointsfilters/covariance_sampling.cpp
     datapointsfilters/cut_at_descriptor_threshold.cpp

--- a/python/datapointsfilters/add_descriptor.cpp
+++ b/python/datapointsfilters/add_descriptor.cpp
@@ -1,0 +1,26 @@
+#include "bounding_box.h"
+
+#include "DataPointsFilters/AddDescriptor.h"
+
+namespace python
+{
+	namespace datapointsfilters
+	{
+		void pybindAddDescriptor(py::module& p_module)
+		{
+			using AddDescriptorDataPointsFilter = AddDescriptorDataPointsFilter<ScalarType>;
+			py::class_<AddDescriptorDataPointsFilter, std::shared_ptr<AddDescriptorDataPointsFilter>, DataPointsFilter>(p_module, "AddDescriptorDataPointsFilter")
+				.def_static("description", &AddDescriptorDataPointsFilter::description)
+				.def_static("availableParameters", &AddDescriptorDataPointsFilter::availableParameters)
+
+				.def_readonly("descriptorName", &AddDescriptorDataPointsFilter::descriptorName)
+				.def_readonly("descriptorDimension", &AddDescriptorDataPointsFilter::descriptorDimension)
+				.def_readonly("descriptorValues", &AddDescriptorDataPointsFilter::descriptorValues)
+
+				.def(py::init<const Parameters&>(), py::arg("params") = Parameters(), "Constructor, uses parameter interface")
+
+				.def("filter", &AddDescriptorDataPointsFilter::filter, py::arg("input"))
+				.def("inPlaceFilter", &AddDescriptorDataPointsFilter::inPlaceFilter, py::arg("cloud"));
+		}
+	}
+}

--- a/python/datapointsfilters/add_descriptor.h
+++ b/python/datapointsfilters/add_descriptor.h
@@ -1,0 +1,14 @@
+#ifndef PYTHON_DATAPOINTSFILTERS_ADD_DESCRIPTOR_H
+#define PYTHON_DATAPOINTSFILTERS_ADD_DESCRIPTOR_H
+
+#include "pypoint_matcher_helper.h"
+
+namespace python
+{
+	namespace datapointsfilters
+	{
+		void pybindAddDescriptor(py::module& p_module);
+	}
+}
+
+#endif //PYTHON_DATAPOINTSFILTERS_ADD_DESCRIPTOR_H

--- a/utest/ui/DataFilters.cpp
+++ b/utest/ui/DataFilters.cpp
@@ -978,7 +978,7 @@ TEST_F(DataFilterTest, AddDescriptorDataPointsFilter)
 	EXPECT_EQ(cloud.getDescriptorDim()+descriptorDimension, filteredCloud.getDescriptorDim());
 	EXPECT_EQ(cloud.getTimeDim(), filteredCloud.getTimeDim());
 
-    Eigen::RowVectorX<float> row = Eigen::RowVectorX<float>::Ones(cloud.getNbPoints());
+    Eigen::Matrix<float, 1, Eigen::Dynamic> row = Eigen::Matrix<float, 1, Eigen::Dynamic>::Ones(cloud.getNbPoints());
     EXPECT_EQ(filteredCloud.descriptorLabels.back().text, descriptorName);
     EXPECT_EQ(filteredCloud.descriptorLabels.back().span, descriptorDimension);
     for(unsigned i = 0; i < descriptorDimension; ++i)

--- a/utest/ui/DataFilters.cpp
+++ b/utest/ui/DataFilters.cpp
@@ -950,3 +950,47 @@ TEST_F(DataFilterTest, SpectralDecompositionDataPointsFilter)
 	addFilter("SpectralDecompositionDataPointsFilter", params);
 	validate3dTransformation();
 }
+
+TEST_F(DataFilterTest, AddDescriptorDataPointsFilter)
+{
+	using DPFiltersPtr = std::shared_ptr<PM::DataPointsFilter>;
+
+	// Test with point cloud
+	DP cloud = generateRandomDataPoints(100);
+
+    std::string descriptorName = "test_descriptor";
+    std::size_t descriptorDimension = 3;
+    std::vector<float> descriptorValues{2, 3, 4};
+
+	// This filter adds a new descriptor
+	params = PM::Parameters();
+		params["descriptorName"] = descriptorName;
+		params["descriptorDimension"] = toParam(descriptorDimension);
+		params["descriptorValues"] = toParam(descriptorValues);
+
+	DPFiltersPtr addDescriptorFilter = PM::get().DataPointsFilterRegistrar.create(
+		"AddDescriptorDataPointsFilter", params
+	);
+
+	DP filteredCloud = addDescriptorFilter->filter(cloud);
+
+	EXPECT_EQ(cloud.getNbPoints(), filteredCloud.getNbPoints());
+	EXPECT_EQ(cloud.getDescriptorDim()+descriptorDimension, filteredCloud.getDescriptorDim());
+	EXPECT_EQ(cloud.getTimeDim(), filteredCloud.getTimeDim());
+
+    Eigen::RowVectorX<float> row = Eigen::RowVectorX<float>::Ones(cloud.getNbPoints());
+    EXPECT_EQ(filteredCloud.descriptorLabels.back().text, descriptorName);
+    EXPECT_EQ(filteredCloud.descriptorLabels.back().span, descriptorDimension);
+    for(unsigned i = 0; i < descriptorDimension; ++i)
+    {
+        EXPECT_EQ(filteredCloud.descriptors.row(filteredCloud.descriptors.rows()-3+i), row*descriptorValues[i]);
+    }
+
+	params = PM::Parameters();
+		params["descriptorName"] = "my_descriptor";
+		params["descriptorDimension"] = toParam(descriptorDimension);
+		params["descriptorValues"] = "[2, 3, 4]";
+
+	addFilter("AddDescriptorDataPointsFilter", params);
+	validate3dTransformation();
+}

--- a/utest/ui/DataFilters.cpp
+++ b/utest/ui/DataFilters.cpp
@@ -986,6 +986,30 @@ TEST_F(DataFilterTest, AddDescriptorDataPointsFilter)
         EXPECT_EQ(filteredCloud.descriptors.row(filteredCloud.descriptors.rows()-3+i), row*descriptorValues[i]);
     }
 
+
+    descriptorValues = std::vector<float>{-2, -3, -4};
+    params["descriptorValues"] = toParam(descriptorValues);
+
+	addDescriptorFilter = PM::get().DataPointsFilterRegistrar.create(
+		"AddDescriptorDataPointsFilter", params
+	);
+	DP filteredCloudOvewriteParams = addDescriptorFilter->filter(filteredCloud);
+    EXPECT_EQ(filteredCloudOvewriteParams.descriptorLabels.back().text, descriptorName);
+    EXPECT_EQ(filteredCloudOvewriteParams.descriptorLabels.back().span, descriptorDimension);
+    for(unsigned i = 0; i < descriptorDimension; ++i)
+    {
+        EXPECT_EQ(filteredCloudOvewriteParams.descriptors.row(filteredCloud.descriptors.rows()-3+i), row*descriptorValues[i]);
+    }
+
+
+    descriptorValues = std::vector<float>{-2, -3, -4, -5};
+    params["descriptorDimension"] = toParam(4);
+    params["descriptorValues"] = toParam(descriptorValues);
+	addDescriptorFilter = PM::get().DataPointsFilterRegistrar.create(
+		"AddDescriptorDataPointsFilter", params
+	);
+    EXPECT_THROW(addDescriptorFilter->filter(filteredCloud), std::runtime_error);
+
 	params = PM::Parameters();
 		params["descriptorName"] = "my_descriptor";
 		params["descriptorDimension"] = toParam(descriptorDimension);

--- a/utest/ui/IO.cpp
+++ b/utest/ui/IO.cpp
@@ -25,6 +25,9 @@ TEST(IOTest, loadYaml)
 	
 	std::ifstream ifs3((dataPath + "unit_tests/badIcpConfig_InvalidModuleType.yaml").c_str());
 	EXPECT_THROW(icp.loadFromYaml(ifs3), PointMatcherSupport::InvalidModuleType);
+
+	std::ifstream ifs4((dataPath + "add_descriptor_config.yaml").c_str());
+	EXPECT_NO_THROW(PM::DataPointsFilters filters(ifs4));
 }
 
 TEST(IOTest, loadCSV)


### PR DESCRIPTION
This DataPointFilter adds a new descriptor with a given **name**, **dimension**, and **values** to the point cloud on which it is applied. It can be used, for example, when a map-building algorithm requires the scans to have the same descriptor as the existing map.
