### PR TITLE
Fixes to CMake library management config generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.8)
 
 include(GNUInstallDirs) # populate CMAKE_INSTALL_{LIB,BIN}DIR
 include(CheckSymbolExists)
+include(CMakePackageConfigHelpers)
 
 
 #========================
@@ -26,12 +27,8 @@ endif ()
 string(REGEX REPLACE ".*\"(.*)\".*" "\\1" POINTMATCHER_PROJECT_VERSION "${POINTMATCHER_PROJECT_VERSION}")
 
 # In 3.0+, project(...) should specify VERSION to satisfy CMP0048
-if (CMAKE_VERSION VERSION_LESS 3.0.0)
-	project(libpointmatcher)
-else ()
-	cmake_policy(SET CMP0048 NEW)
-	project(libpointmatcher VERSION ${POINTMATCHER_PROJECT_VERSION})
-endif ()
+cmake_policy(SET CMP0048 NEW)
+project(libpointmatcher VERSION ${POINTMATCHER_PROJECT_VERSION})
 
 set(CMAKE_DEBUG_POSTFIX "d")
 
@@ -425,7 +422,7 @@ set(GENERATE_API_DOC false CACHE BOOL "Set to true to build the documentation us
 
 if(GENERATE_API_DOC)
 
-	message("-- API Documentation (doxygen): enabled")
+	message(STATUS "API Documentation (doxygen): enabled")
 
 	# Note: there seems to be equations in the documentation leading to the
 	# use of Latex anyway. This cause problems for user without latex...
@@ -444,13 +441,13 @@ endif()
 
 #=============== trigger other makefile ======================
 
-# Example programs
+# Example programs TODO
 option(POINTMATCHER_BUILD_EXAMPLES "Build libpointmatcher examples" ON)
 if (POINTMATCHER_BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()
 
-# Evaluation programs
+# Evaluation programs TODO
 option(POINTMATCHER_BUILD_EVALUATIONS "Build libpointmatcher evaluations" ON)
 if (POINTMATCHER_BUILD_EVALUATIONS)
   add_subdirectory(evaluations)
@@ -483,6 +480,8 @@ endif()
 #  target_link_libraries(executableName ${libpointmatcher_LIBRARIES})
 #  ...
 
+# 1- local build #
+
 # Install cmake config module
 install(EXPORT ${PROJECT_NAME}-config DESTINATION share/${PROJECT_NAME}/cmake)
 
@@ -500,27 +499,27 @@ get_property(CONF_INCLUDE_DIRS DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY IN
 set(POINTMATCHER_LIB  $<TARGET_FILE:pointmatcher>)
 
 # Configure config file for local build tree
-configure_file(libpointmatcherConfig.cmake.in
-  "${PROJECT_BINARY_DIR}/libpointmatcherConfig.cmake" @ONLY)
+configure_package_config_file(libpointmatcherConfig.cmake.in
+  "${PROJECT_BINARY_DIR}/libpointmatcherConfig.cmake"
+  		INSTALL_DESTINATION share/libnabo/cmake
+		PATH_VARS PROJECT_NAME
+		)
 
 # 2- installation build #
 
 # Change the include location for the case of an install location
 set(CONF_INCLUDE_DIRS ${INSTALL_INCLUDE_DIR} ${CONF_INCLUDE_DIRS} )
 
-#FIXME: this will only be applied to installed files. Confirm that we want that.
-# gather all the includes but remove ones in the source tree
-# because we added an include for the local yaml-cpp-pm we should also remove it
-list(REMOVE_ITEM CONF_INCLUDE_DIRS ${CMAKE_SOURCE_DIR})
-
 # We put the generated file for installation in a different repository (i.e., ./CMakeFiles/)
-configure_file(libpointmatcherConfig.cmake.in
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/libpointmatcherConfig.cmake" @ONLY)
+configure_package_config_file(libpointmatcherConfig.cmake.in
+  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/libpointmatcherConfig.cmake"
+  		INSTALL_DESTINATION share/libnabo/cmake
+		PATH_VARS PROJECT_NAME
+		)
 
 # The same versioning file can be used for both cases
-configure_file(libpointmatcherConfigVersion.cmake.in
-  "${PROJECT_BINARY_DIR}/libpointmatcherConfigVersion.cmake" @ONLY)
-
+write_basic_package_version_file(libpointmatcherConfigVersion.cmake
+		COMPATIBILITY AnyNewerVersion)
 
 # Install the libpointmatcherConfig.cmake and libpointmatcherConfigVersion.cmake
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,12 +220,9 @@ endif()
 
 message(STATUS "Looking for yaml-cpp on system...")
 
-find_package(yaml-cpp QUIET)
-
-if(yaml-cpp_FOUND)
-        message(STATUS "yaml-cpp version ${yaml-cpp_VERSION} found, text-based configuration enabled")
-else()
-        message(STATUS "yaml-cpp not found, text-based configuration and related applications disabled")
+find_package(yaml-cpp CONFIG REQUIRED)
+if(TARGET yaml-cpp::yaml-cpp)
+	set(YAML_CPP_LIBRARIES "yaml-cpp::yaml-cpp")
 endif()
 
 #--------------------
@@ -360,7 +357,7 @@ target_include_directories(pointmatcher PUBLIC
   $<INSTALL_INTERFACE:pointmatcher>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/pointmatcher>
-	$<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
+  $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
 )
 
 if (NOT MSVC)
@@ -369,10 +366,8 @@ else()
 	target_compile_options(pointmatcher PRIVATE /bigobj)
 endif()
 
-if(yaml-cpp_FOUND)
-	target_link_libraries(pointmatcher PUBLIC ${YAML_CPP_LIBRARIES})
-	target_include_directories(pointmatcher PUBLIC ${YAML_CPP_INCLUDE_DIR})
-endif()
+target_link_libraries(pointmatcher PUBLIC ${YAML_CPP_LIBRARIES})
+target_include_directories(pointmatcher PUBLIC ${YAML_CPP_INCLUDE_DIR})
 
 target_link_libraries(pointmatcher PUBLIC ${Boost_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,11 +216,13 @@ endif()
 #--------------------
 
 message(STATUS "Looking for yaml-cpp on system...")
-
 find_package(yaml-cpp CONFIG REQUIRED)
 if(TARGET yaml-cpp::yaml-cpp)
 	set(YAML_CPP_LIBRARIES "yaml-cpp::yaml-cpp")
 endif()
+if(YAML_CPP_LIBRARIES STREQUAL "")
+	set(YAML_CPP_LIBRARIES "yaml-cpp") # Fix linking issue on MacOS with yaml-cpp 0.7.0
+endif ()
 
 #--------------------
 # DEPENDENCY: rt (optional)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,22 +441,20 @@ endif()
 
 #=============== trigger other makefile ======================
 
-# Example programs TODO
-option(POINTMATCHER_BUILD_EXAMPLES "Build libpointmatcher examples" ON)
-if (POINTMATCHER_BUILD_EXAMPLES)
+# Example programs
+option(BUILD_EXAMPLES "Build libpointmatcher examples" ON)
+if (BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()
 
-# Evaluation programs TODO
-option(POINTMATCHER_BUILD_EVALUATIONS "Build libpointmatcher evaluations" ON)
-if (POINTMATCHER_BUILD_EVALUATIONS)
+# Evaluation programs
+option(BUILD_EVALUATIONS "Build libpointmatcher evaluations" ON)
+if (BUILD_EVALUATIONS)
   add_subdirectory(evaluations)
 endif()
 
 # Unit testing
-
 option(BUILD_TESTS "Build all tests." OFF)
-
 if (BUILD_TESTS)
 	enable_testing()
 	add_subdirectory(utest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,8 @@ if (NOT TARGET nabo)
   # Find libnabo:
   find_package(libnabo REQUIRED PATHS ${LIBNABO_INSTALL_DIR})
   if (TARGET libnabo::nabo)
-    message(STATUS "libnabo found, version ${libnabo_VERSION} (Config mode)")
+ 	set(libnabo_LIBRARIES libnabo::nabo)
+    message(STATUS "libnabo found, version ${libnabo_VERSION} (Config mode,  libs=${libnabo_LIBRARIES})")
   else()
     message(STATUS "libnabo found, version ${libnabo_VERSION} (include=${libnabo_INCLUDE_DIRS} libs=${libnabo_LIBRARIES})")
   endif()
@@ -173,7 +174,6 @@ endif()
 # This cmake target alias will be defined by either:
 # a) libnabo sources if built as a git submodule in the same project than this library, or
 # b) by libnabo-targets.cmake, included by find_package(libnabo) above.
-# set(libnabo_LIBRARIES libnabo::nabo)
 
 #--------------------
 # DEPENDENCY: OpenMP (optional)

--- a/doc/CompilationMac.md
+++ b/doc/CompilationMac.md
@@ -114,7 +114,7 @@ brew install eigen
 
 ### 2. Installing yaml-cpp
 
-The straightforward way to install yaml-cpp library through brew was, as for hte end 2023, not functional  
+The straightforward way to install yaml-cpp library through brew was, as for the end of 2023, not functional  
 ```bash
 brew install yaml-cpp
 ```
@@ -122,7 +122,7 @@ Instead, you can install the library from sources. Follow https://github.com/jbe
 ```bash
 mkdir ~/Libraries/
 cd ~/Libraries
-git clone git@github.com:jbeder/yaml-cpp.git
+git clone -b yaml-cpp-0.7.0 git@github.com:jbeder/yaml-cpp.git
 cd yaml-cpp
 ```
 Now you can compile and install yaml-cpp by entering the following commands
@@ -131,7 +131,7 @@ Now you can compile and install yaml-cpp by entering the following commands
 SRC_DIR=$PWD
 BUILD_DIR=${SRC_DIR}/build
 mkdir -p ${BUILD_DIR} && cd ${BUILD_DIR}
-cmake ..
+cmake -DBUILD_TESTING=FALSE ..
 make
 sudo make install
 ```

--- a/libpointmatcherConfig.cmake.in
+++ b/libpointmatcherConfig.cmake.in
@@ -2,6 +2,7 @@
 # It defines the following variables
 #  libpointmatcher_INCLUDE_DIRS - include directories for pointmatcher
 #  libpointmatcher_LIBRARIES    - libraries to link against
+@PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
 find_dependency(libnabo REQUIRED)
@@ -10,23 +11,10 @@ if (Boost_MINOR_VERSION GREATER 47)
   find_package(Boost COMPONENTS thread filesystem system program_options date_time chrono REQUIRED)
 endif ()
 include(${CMAKE_CURRENT_LIST_DIR}/libpointmatcher-config.cmake)
-#include(${CMAKE_CURRENT_LIST_DIR}/yaml-cpp-pm-targets.cmake)
 
 # Compute paths
 get_filename_component(POINTMATCHER_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 set(libpointmatcher_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
-set(LIBPOINTMATCHER_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
-set(pointmatcher_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
-set(POINTMATCHER_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
-set(libpointmatcher_INCLUDE_DIR "@CONF_INCLUDE_DIRS@")
+set(libpointmatcher_LIBRARIES "@POINTMATCHER_LIB@;@YAML_CPP_LIBRARIES@;@libnabo_LIBRARIES@;@EXTERNAL_LIBS@;@Boost_LIBRARIES@")
 
-set(libpointmatcher_LIBRARIES "@POINTMATCHER_LIB@;@libnabo_LIBRARIES@;@EXTERNAL_LIBS@;@Boost_LIBRARIES@")
-set(LIBPOINTMATCHER_LIBRARIES "@POINTMATCHER_LIB@;@libnabo_LIBRARIES@;@EXTERNAL_LIBS@;@Boost_LIBRARIES@")
-set(pointmatcher_LIBRARIES "@POINTMATCHER_LIB@;@libnabo_LIBRARIES@;@EXTERNAL_LIBS@;@Boost_LIBRARIES@")
-set(POINTMATCHER_LIBRARIES "@POINTMATCHER_LIB@;@libnabo_LIBRARIES@;@EXTERNAL_LIBS@;@Boost_LIBRARIES@")
-
-# This causes catkin simple to link against these libraries
-set(libpointmatcher_FOUND_CATKIN_PROJECT true)
-set(LIBPOINTMATCHER_FOUND_CATKIN_PROJECT true)
-set(pointmatcher_FOUND_CATKIN_PROJECT true)
-set(POINTMATCHER_FOUND_CATKIN_PROJECT true)
+check_required_components("@PROJECT_NAME@")

--- a/package.xml
+++ b/package.xml
@@ -13,10 +13,12 @@
 	<build_depend>boost</build_depend>
 	<build_depend>libnabo</build_depend>
 	<build_depend>eigen</build_depend>
+	<build_depend>yaml-cpp</build_depend>
 
 	<exec_depend>boost</exec_depend>
 	<exec_depend>libnabo</exec_depend>
 	<exec_depend>eigen</exec_depend>
+	<exec_depend>yaml-cpp</exec_depend>
 	<exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
 
 	<export>

--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,7 @@
 	</description>
 	<maintainer email="f.pomerleau@gmail.com">Francois Pomerleau</maintainer>
 	<license>BSD</license>
-	<url type="repository">https://github.com/ethz-asl/libpointmatcher</url>
+	<url type="repository">https://github.com/norlab-ulaval/libpointmatcher</url>
 
 	<buildtool_depend>cmake</buildtool_depend>
 


### PR DESCRIPTION
This commit contains the following changes:

1. Fix the issue when `libnabo` is not linked properly and executables using `libpointmatcher` are not built (see https://github.com/norlab-ulaval/libpointmatcher/issues/526). Tested on both the [HEAD](https://github.com/norlab-ulaval/libnabo) and [1.0.7](https://github.com/norlab-ulaval/libnabo/releases/tag/1.0.7) of `libnabo`.
2. Set the supported version of `yaml-cpp` on MacOS to [0.7.0](https://github.com/jbeder/yaml-cpp/releases/tag/yaml-cpp-0.7.0) and edit the documentation accordingly.
3. Modify CMakeLists.txt to make use of the [CMakePackageConfigHelpers](https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html) 