### PR TITLE
fix: build-system side unstable compilation issue fix [NMO-402]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Files or directories with designated code owner.
+# Branch with "Require review from Code Owners" will automaticaly trigger a request to a designated code owner
+
+# DevOps related
+/build_system/ @RedLeader962
+/.github/ @RedLeader962
+/.dockerignore @RedLeader962
+/.gitignore @RedLeader962
+
+# Core
+/pointmatcher @boxanm @simonpierredeschenes @aguenette
+/python @boxanm @simonpierredeschenes @aguenette
+/utest @boxanm @simonpierredeschenes @aguenette

--- a/build_system/docker-compose.libpointmatcher.yaml
+++ b/build_system/docker-compose.libpointmatcher.yaml
@@ -1,6 +1,6 @@
 services:
 
-  # ====Dependency related services===================================================================================
+  # ====Dependency related services================================================================
   dependencies:
     image: ${LPM_PROJECT_DOCKERHUB:?err}/libpointmatcher-dependencies:${LPM_IMAGE_TAG:?err}
     build:
@@ -34,7 +34,7 @@ services:
     tty: true
     stdin_open: true
 
-  # ====Pull-request related services================================================================================
+  # ====Pull-request related services==============================================================
   ci_PR:
     image: ${LPM_PROJECT_DOCKERHUB:?err}/libpointmatcher-ci-pr:${LPM_IMAGE_TAG:?err}
     pull_policy: build
@@ -53,14 +53,20 @@ services:
     tty: true
     stdin_open: true
     init: true  # Propagate exit code (See remark in task NMO-266)
+    depends_on:
+      - dependencies
   ci_PR_amd64:
     extends: ci_PR
-    platform: "linux/amd64"
+    build:
+      platforms:
+        - "linux/amd64"
   ci_PR_arm64v8:
     extends: ci_PR
-    platform: "linux/arm64/v8"
+    build:
+      platforms:
+        - "linux/arm64/v8"
 
-  # ====Build system assessment services==============================================================================
+  # ====Build system assessment services===========================================================
   ci_SITREP_matrix:
     image: ${LPM_PROJECT_DOCKERHUB:?err}/libpointmatcher-ci-sitrep-matrix:${LPM_IMAGE_TAG:?err}
     pull_policy: build
@@ -86,7 +92,7 @@ services:
     extends: ci_SITREP_matrix
     platform: "linux/arm64/v8"
 
-  # ====Dockerhub release image======================================================================================
+  # ====Dockerhub release image====================================================================
   release:
     image: ${LPM_PROJECT_DOCKERHUB:?err}/libpointmatcher:${LPM_IMAGE_TAG:?err}
     container_name: libpointmatcher

--- a/build_system/ubuntu/lpm_install_dependencies_ubuntu.bash
+++ b/build_system/ubuntu/lpm_install_dependencies_ubuntu.bash
@@ -7,14 +7,14 @@
 #
 set -e # Note: we want the installer to always fail-fast (it wont affect the build system policy)
 
-# ....Project root logic...........................................................................................
+# ....Project root logic...........................................................................
 TMP_CWD=$(pwd)
 
 if [[ "$(basename $(pwd))" != "build_system" ]]; then
   cd ../
 fi
 
-# ....Load environment variables from file.........................................................................
+# ....Load environment variables from file.........................................................
 set -o allexport
 source ./.env
 source ./.env.prompt
@@ -23,7 +23,7 @@ set +o allexport
 # skip GUI dialog by setting everything to default
 export DEBIAN_FRONTEND=noninteractive
 
-# ....Helper function..............................................................................................
+# ....Helper function..............................................................................
 ## import shell functions from Libpointmatcher-build-system utilities library
 source ./function_library/prompt_utilities.bash
 source ./function_library/terminal_splash.bash
@@ -32,7 +32,7 @@ source ./function_library/general_utilities.bash
 # Set environment variable LPM_IMAGE_ARCHITECTURE
 source ./lpm_utility_script/lpm_export_which_architecture.bash
 
-# ====Begin========================================================================================================
+# ====Begin========================================================================================
 SHOW_SPLASH_IDU="${SHOW_SPLASH_IDU:-true}"
 
 if [[ "${SHOW_SPLASH_IDU}" == 'true' ]]; then
@@ -41,7 +41,7 @@ fi
 
 print_formated_script_header "lpm_install_dependencies_ubuntu.bash (${LPM_IMAGE_ARCHITECTURE})" "${LPM_LINE_CHAR_INSTALLER}"
 
-# ................................................................................................................
+# .................................................................................................
 teamcity_service_msg_blockOpened "Install development utilities"
 
 sudo apt-get update &&
@@ -63,7 +63,7 @@ sudo apt-get update &&
 cmake --version
 
 teamcity_service_msg_blockClosed
-# ................................................................................................................
+# .................................................................................................
 
 if [[ ${IS_TEAMCITY_RUN} == true ]]; then
   print_msg "The install script is run in teamCity >> the python install step was executed earlier in the Dockerfile.dependencies"
@@ -72,7 +72,7 @@ else
   source ./ubuntu/lpm_install_python_dev_tools.bash
 fi
 
-# ................................................................................................................
+# .................................................................................................
 teamcity_service_msg_blockOpened "Install Libpointmatcher dependencies › Boost"
 # https://www.boost.org/doc/libs/1_79_0/more/getting_started/unix-variants.html
 
@@ -82,7 +82,7 @@ sudo apt-get update &&
   sudo rm -rf /var/lib/apt/lists/*
 
 teamcity_service_msg_blockClosed
-# ................................................................................................................
+# .................................................................................................
 teamcity_service_msg_blockOpened "Install Libpointmatcher dependencies › Eigen"
 # https://eigen.tuxfamily.org/index.php
 
@@ -92,7 +92,7 @@ sudo apt-get update &&
   sudo rm -rf /var/lib/apt/lists/*
 
 teamcity_service_msg_blockClosed
-# ................................................................................................................
+# .................................................................................................
 teamcity_service_msg_blockOpened "Install Libpointmatcher dependencies › Libnabo"
 # https://github.com/ethz-asl/libnabo
 
@@ -136,6 +136,8 @@ git clone https://github.com/ethz-asl/libnabo.git &&
 
 teamcity_service_msg_compilationStarted "cmake"
 
+# (Priority) inprogress: investigate?? (ref task NMO-402 fix: unstable compilation issue)
+# ToDo: Add mention about 'CMAKE_INSTALL_PREFIX' in the doc install step as a fix
 cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo \
  -D CMAKE_INSTALL_PREFIX=${LPM_INSTALLED_LIBRARIES_PATH} \
  "${LPM_INSTALLED_LIBRARIES_PATH}/libnabo" &&
@@ -143,10 +145,11 @@ cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo \
   make test &&
   sudo make install
 
+
 teamcity_service_msg_compilationFinished
 
 teamcity_service_msg_blockClosed
-# ................................................................................................................
+# .................................................................................................
 teamcity_service_msg_blockOpened "Install Libpointmatcher dev tools"
 
 sudo apt-get update &&
@@ -158,5 +161,5 @@ teamcity_service_msg_blockClosed
 
 echo " " && print_msg_done "Libpointmatcher dependencies installed"
 print_formated_script_footer "lpm_install_dependencies_ubuntu.bash (${LPM_IMAGE_ARCHITECTURE})" "${LPM_LINE_CHAR_INSTALLER}"
-# ====Teardown=====================================================================================================
+# ====Teardown=====================================================================================
 cd "${TMP_CWD}"

--- a/build_system/ubuntu/lpm_install_libpointmatcher_ubuntu.bash
+++ b/build_system/ubuntu/lpm_install_libpointmatcher_ubuntu.bash
@@ -25,21 +25,21 @@
 #
 set -e # Note: we want the installer to always fail-fast (it wont affect the build system policy)
 
-# ....Default......................................................................................................
+# ....Default......................................................................................
 LIBPOINTMATCHER_VERSION='head'
 BUILD_TESTS_FLAG=FALSE
 GENERATE_API_DOC_FLAG=FALSE
 BUILD_SYSTEM_CI_INSTALL=FALSE
 CMAKE_BUILD_TYPE=RelWithDebInfo
 
-# ....Project root logic...........................................................................................
+# ....Project root logic...........................................................................
 TMP_CWD=$(pwd)
 
 if [[ "$(basename $(pwd))" != "build_system" ]]; then
   cd ../
 fi
 
-# ....Load environment variables from file.........................................................................
+# ....Load environment variables from file.........................................................
 set -o allexport
 source ./.env
 source ./.env.prompt
@@ -48,7 +48,7 @@ set +o allexport
 ## skip GUI dialog by setting everything to default
 export DEBIAN_FRONTEND=noninteractive
 
-# ....Helper function..............................................................................................
+# ....Helper function..............................................................................
 ## import shell functions from Libpointmatcher-build-system utilities library
 source ./function_library/prompt_utilities.bash
 source ./function_library/terminal_splash.bash
@@ -77,7 +77,7 @@ function print_help_in_terminal() {
   "
 }
 
-# ====Begin========================================================================================================
+# ====Begin========================================================================================
 SHOW_SPLASH_ILU="${SHOW_SPLASH_ILU:-true}"
 
 if [[ "${SHOW_SPLASH_ILU}" == 'true' ]]; then
@@ -87,7 +87,7 @@ fi
 print_formated_script_header "lpm_install_libpointmatcher_ubuntu.bash (${LPM_IMAGE_ARCHITECTURE})" "${LPM_LINE_CHAR_INSTALLER}"
 
 
-# ....Script command line flags....................................................................................
+# ....Script command line flags....................................................................
 
 while [ $# -gt 0 ]; do
 
@@ -139,7 +139,7 @@ while [ $# -gt 0 ]; do
 
 done
 
-# ................................................................................................................
+# .................................................................................................
 teamcity_service_msg_blockOpened "Install Libpointmatcher"
 # https://github.com/ethz-asl/libpointmatcher/tree/master
 
@@ -178,12 +178,17 @@ teamcity_service_msg_compilationStarted "cmake"
 # (CRITICAL) ToDo: validate >> GENERATE_API_DOC install dir
 
 
+# (Priority) inprogress: investigate?? (ref task NMO-402 fix: unstable compilation issue)
 cmake -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
   -D BUILD_TESTS=${BUILD_TESTS_FLAG} \
   -D GENERATE_API_DOC=${GENERATE_API_DOC_FLAG} \
-  -D LIBNABO_INSTALL_DIR="${LPM_INSTALLED_LIBRARIES_PATH}/libnabo" \
   -D CMAKE_INSTALL_PREFIX="${LPM_INSTALLED_LIBRARIES_PATH}" \
   "${LPM_INSTALLED_LIBRARIES_PATH}/${LPM_LIBPOINTMATCHER_SRC_REPO_NAME}"
+
+# Note:
+#   - Previously use intall flag quick-hack to work around the install issue.
+#   - Keep it here as futur reference
+#  -D LIBNABO_INSTALL_DIR="${LPM_INSTALLED_LIBRARIES_PATH}/libnabo" \
 
 BUILD_EXIT_CODE=$?
 
@@ -234,5 +239,5 @@ else
 fi
 
 print_formated_script_footer "lpm_install_libpointmatcher_ubuntu.bash (${LPM_IMAGE_ARCHITECTURE})" "${LPM_LINE_CHAR_INSTALLER}"
-# ====Teardown=====================================================================================================
+# ====Teardown=====================================================================================
 cd "${TMP_CWD}"


### PR DESCRIPTION
- update the libpointmatcher cmake flag following the PR #538 fix
- added note for futur refenrences
- added codeowner file
- several linting related file cleanup

Note: we keept the `CMAKE_INSTALL_PREFIX` for build the build-system cmake install