### PR TITLE
Update the minimum required Cmake version to 3.10.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10.2)
 
 include(GNUInstallDirs) # populate CMAKE_INSTALL_{LIB,BIN}DIR
 include(CheckSymbolExists)


### PR DESCRIPTION
# Description

### Summary:
CMake 3.10.2 is the default version on Ubuntu 18, so it's the minimum version we should require.