### PR TITLE
Release 1.4.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package libpointmatcher
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.4.1 (2024-03-19)
+-----------------
+* Update package.xml version properly
+
 1.4.0 (2023-12-15)
 -----------------
 * fix: N2ST path resolution in dependencies-doc docker image

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package format="3">
 	<name>libpointmatcher</name>
-	<version>1.3.1</version>
+	<version>1.4.1</version>
 	<description>
 		libpointmatcher is a modular ICP library, useful for robotics and computer vision.
 	</description>


### PR DESCRIPTION
# Description

Do a release of 1.4.1 for libpointmatcher

### Summary:

The source release of 1.4.0 was done on this repository without bumping the package.xml version. This means that that version cannot be released on the ROS 2 buildfarm to fix https://build.ros2.org/view/Rbin_uN64/job/Rsrc_uN__libpointmatcher__ubuntu_noble__source/

Instead of moving the tag or any other git shenanigans, just make a new release 1.4.1 that properly updates the CHANGELOG and bumps the package.xml. Once this is merged in, I'll need one of the maintainers to also create a tag (1.4.1), at which point we can bloom-release this and fix the build on the ROS 2 buildfarm.

### Changes and type of changes (quick overview):

- 1.4.1 release

---

# Checklist:

### Code related

- [N/A] I have made corresponding changes to the documentation 
      (i.e.: function, class, script header, README.md)
- [N/A] I have commented hard-to-understand code
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [N/A] All tests pass locally with my changes 
      (Check [README.md #Contributing](https://github.com/norlab-ulaval/libpointmatcher/tree/develop#contributing)
      for local testing procedure using _libpointmatcher-build-system_)

### PR creation related

- [ ] My pull request `base ref` branch is set to the `develop` branch 
     (the _build-system_ won't be triggered otherwise)
- [ ] My pull request branch is up-to-date with the `develop` branch 
     (the _build-system_ will reject it otherwise)

### PR description related

- [ ] I have included a quick summary of the changes
- [ ] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`
- [ ] I have included a high-level list of changes and their corresponding type
    - Types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `build` `ci` `chore` `revert`
    - Breaking changes: `<type>!`
    - Reference:
      see [commit_msg_reference.md](https://github.com/norlab-ulaval/libpointmatcher/blob/develop/commit_msg_reference.md)
      in the repository root for details

---

## Note for repository admins

### Release PR related

- Only repository admins have the privilege to `push/merge` on the default branch (ie: `master`)
  and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release.
- Once a PR from `release` -> `master` branch is created (not in draft mode),
    - it triggers the _build-system_ test
    - (in-progress) and it triggers the _semantic release automation_
