### PR TITLE
Load DataPointsFilters config from a YAML::Node object

### DIFF
--- a/pointmatcher/DataPointsFilter.cpp
+++ b/pointmatcher/DataPointsFilter.cpp
@@ -68,21 +68,25 @@ template<typename T>
 PointMatcher<T>::DataPointsFilters::DataPointsFilters()
 {}
 
-//! Construct a chain from a YAML file
 template<typename T>
-PointMatcher<T>::DataPointsFilters::DataPointsFilters(std::istream& in)
+PointMatcher<T>::DataPointsFilters::DataPointsFilters(const YAML::Node& doc)
 {
-	YAML::Node doc = YAML::Load(in);
-	
 	// Fix for issue #6: compilation on gcc 4.4.4
 	//PointMatcher<T> pm;
 	const PointMatcher & pm = PointMatcher::get();
-	
+
 	for(YAML::const_iterator moduleIt = doc.begin(); moduleIt != doc.end(); ++moduleIt)
 	{
 		const YAML::Node& module(*moduleIt);
 		this->push_back(pm.REG(DataPointsFilter).createFromYAML(module));
 	}
+}
+
+//! Construct a chain from a YAML file
+template<typename T>
+PointMatcher<T>::DataPointsFilters::DataPointsFilters(std::istream& in) :
+        DataPointsFilters(YAML::Load(in))
+{
 }
 
 //! Init the chain

--- a/pointmatcher/ICP.cpp
+++ b/pointmatcher/ICP.cpp
@@ -110,14 +110,13 @@ void PointMatcher<T>::ICPChainBase::setDefault()
 
 //! Construct an ICP algorithm from a YAML file
 template<typename T>
-void PointMatcher<T>::ICPChainBase::loadFromYaml(std::istream& in)
+void PointMatcher<T>::ICPChainBase::loadFromYamlNode(const YAML::Node& doc)
 {
 	this->cleanup();
 
-	YAML::Node doc = YAML::Load(in);
 	typedef set<string> StringSet;
 	StringSet usedModuleTypes;
-	
+
 	// Fix for issue #6: compilation on gcc 4.4.4
 	//PointMatcher<T> pm;
 	const PointMatcher & pm = PointMatcher::get();
@@ -140,14 +139,14 @@ void PointMatcher<T>::ICPChainBase::loadFromYaml(std::istream& in)
 		this->transformations.push_back(std::make_shared<typename TransformationsImpl<T>::RigidTransformation>());
 	else
 		this->transformations.push_back(std::make_shared<typename TransformationsImpl<T>::SimilarityTransformation>());
-	
+
 	usedModuleTypes.insert(createModulesFromRegistrar("transformationCheckers", doc, pm.REG(TransformationChecker), transformationCheckers));
 	usedModuleTypes.insert(createModuleFromRegistrar("inspector", doc, pm.REG(Inspector),inspector));
-	
-	
+
+
 	// FIXME: this line cause segfault when there is an error in the yaml file...
 	//loadAdditionalYAMLContent(doc);
-	
+
 	// check YAML entries that do not correspend to any module
 	for(YAML::const_iterator moduleTypeIt = doc.begin(); moduleTypeIt != doc.end(); ++moduleTypeIt)
 	{
@@ -158,6 +157,15 @@ void PointMatcher<T>::ICPChainBase::loadFromYaml(std::istream& in)
 				(boost::format("Module type %1% does not exist") % moduleType).str()
 			);
 	}
+
+}
+
+//! Construct an ICP algorithm from a YAML file
+template<typename T>
+void PointMatcher<T>::ICPChainBase::loadFromYaml(std::istream& in)
+{
+	YAML::Node doc = YAML::Load(in);
+    loadFromYamlNode(doc);
 }
 
 //! Return the remaining number of points in reading after prefiltering but before the iterative process
@@ -526,6 +534,12 @@ void PointMatcher<T>::ICPSequence::setDefault()
 	{
 		this->matcher->init(mapPointCloud);
 	}
+}
+
+template<typename T>
+void PointMatcher<T>::ICPSequence::loadFromYamlNode(const YAML::Node& doc)
+{
+	ICPChainBase::loadFromYamlNode(doc);
 }
 
 template<typename T>

--- a/pointmatcher/PointMatcher.h
+++ b/pointmatcher/PointMatcher.h
@@ -455,6 +455,7 @@ struct PointMatcher
 	struct DataPointsFilters: public std::vector<std::shared_ptr<DataPointsFilter> >
 	{
 		DataPointsFilters();
+		DataPointsFilters(const YAML::Node& doc);
 		DataPointsFilters(std::istream& in);
 		void init();
 		void apply(DataPoints& cloud);

--- a/pointmatcher/PointMatcher.h
+++ b/pointmatcher/PointMatcher.h
@@ -670,6 +670,7 @@ struct PointMatcher
 		virtual void setDefault();
 		
 		virtual void loadFromYaml(std::istream& in);
+		virtual void loadFromYamlNode(const YAML::Node& doc);
 		unsigned getPrefilteredReadingPtsCount() const;
 		unsigned getPrefilteredReferencePtsCount() const;
 
@@ -746,6 +747,7 @@ struct PointMatcher
 		void clearMap();
 		virtual void setDefault();
 		virtual void loadFromYaml(std::istream& in);
+		virtual void loadFromYamlNode(const YAML::Node& doc);
 		PM_DEPRECATED("Use getPrefilteredInternalMap instead. "
 			            "Function now always returns map with filter chain applied. "
 			            "This may have altered your program behavior."


### PR DESCRIPTION
# Description

### Summary:
I opened the API to load YAML files so that a configuration can also be created from a node, not just a stream.
This effort is to prepare `libpointmatcher` for the upcoming changes in the configuration of the `norlab_icp_mapper`. Check [this PR.](https://github.com/norlab-ulaval/norlab_icp_mapper/pull/15).

### Changes and type of changes (quick overview):

- add a function that loads DataPointsFilters from a YAML::Node object
