### PR TITLE
Getter for available Descriptor's parame…

### DIFF
--- a/pointmatcher/Registrar.h
+++ b/pointmatcher/Registrar.h
@@ -180,6 +180,12 @@ namespace PointMatcherSupport
 			return getDescriptor(name)->description();
 		}
 
+		//! Get all available parameters of a class
+		const Parametrizable::ParametersDoc getAvailableParameters(const std::string& name) const
+		{
+			return getDescriptor(name)->availableParameters();
+		}
+
 		//! Print the list of registered classes to stream
 		void dump(std::ostream &stream) const
 		{

--- a/python/pointmatchersupport/registrars/data_points_filter_registrar.cpp
+++ b/python/pointmatchersupport/registrars/data_points_filter_registrar.cpp
@@ -12,6 +12,7 @@ namespace python
 					.def("getDescriptor", &DataPointsFilterRegistrar::getDescriptor, py::arg("name"), "Return a descriptor following a name, throw an exception if name is invalid")
 					.def("create", &DataPointsFilterRegistrar::create, py::arg("name"), py::arg("params") = Parameters(), "Create an instance")
 					.def("getDescription", &DataPointsFilterRegistrar::getDescription, py::arg("name"), "Get the description of a class")
+                    .def("getAvailableParameters", &DataPointsFilterRegistrar::getAvailableParameters, py::arg("name"), "Get all available parameters of a class")
 					.def("dump", [](const DataPointsFilterRegistrar& self)
 					{
 						std::ostringstream oss;


### PR DESCRIPTION
# Description

### Summary:

Add a method that returns a list of all available Descriptor's parameters.
This effort is to prepare `libpointmatcher` for the upcoming changes in the configuration of the `norlab_icp_mapper`. Check [this PR](https://github.com/norlab-ulaval/norlab_icp_mapper/pull/15).
