### PR TITLE
Fix compile error with clang

### DIFF
--- a/pointmatcher/PointCloudGenerator.cpp
+++ b/pointmatcher/PointCloudGenerator.cpp
@@ -170,7 +170,7 @@ typename PointMatcher<T>::DataPoints PointMatcher<T>::PointCloudGenerator::gener
     {
         // Sample random values of theta and phi.
         const ScalarType phi{ 2.0f * pi * uniformDistribution(randomNumberGenerator) };
-        const ScalarType radiusSample{ radius * sqrt(uniformDistribution(randomNumberGenerator)) };
+        const ScalarType radiusSample{ static_cast<ScalarType>(radius * sqrt(uniformDistribution(randomNumberGenerator))) };
 
         // Pre-compute values, such as sine and cosine of phi and theta.
         const ScalarType sinPhi{ std::sin(phi) };


### PR DESCRIPTION
# Description

### Summary:

My build was failing with clang 18.1.3

```
 error: non-constant-expression cannot be narrowed from type 'double' to 'ScalarType' (aka 'float') in initializer list [-Wc++11-narrowing]
  173 |         const ScalarType radiusSample{ radius * sqrt(uniformDistribution(randomNumberGenerator)) };
```

By inserting a `static_cast` it fixed it