### PR TITLE
Replace boost::timer with std::chrono::steady_clock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,6 +383,11 @@ if (EXTRA_DEPS)
 	add_dependencies(pointmatcher ${EXTRA_DEPS})
 endif()
 
+option(DISABLE_POSIX_TIMERS "Disable POSIX timers" OFF)
+if(DISABLE_POSIX_TIMERS)
+    target_compile_definitions(pointmatcher PRIVATE FORCE_DISABLE_POSIX_TIMERS)
+endif()
+
 if (POSIX_TIMERS AND NOT APPLE)
 	target_link_libraries(pointmatcher PRIVATE rt)
 endif ()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,3 +22,6 @@ target_link_libraries(icp_advance_api pointmatcher)
 
 add_executable(icp_customized icp_customized.cpp)
 target_link_libraries(icp_customized pointmatcher)
+
+add_executable(timer timer.cpp)
+target_link_libraries(timer pointmatcher)

--- a/examples/timer.cpp
+++ b/examples/timer.cpp
@@ -1,0 +1,25 @@
+#include "pointmatcher/Timer.h"
+#include <iostream>
+#include <chrono>
+#include <thread>
+
+namespace Time {
+    using Clock = std::chrono::high_resolution_clock;
+    using TimePoint = std::chrono::time_point<Clock>;
+}
+
+int main() {
+    const Time::TimePoint time1 = Time::Clock::now();
+    PointMatcherSupport::timer t1;
+
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+
+    const Time::TimePoint time2 = Time::Clock::now();
+    const double elapsed = t1.elapsed();
+
+    std::cout << "PM:timer time = " << elapsed << "\nchrono duration = "
+              << std::chrono::duration_cast<std::chrono::nanoseconds>(time2 - time1).count() / double(1000000000)
+              << " ms" << std::endl;
+
+    return 0;
+}

--- a/pointmatcher/Timer.cpp
+++ b/pointmatcher/Timer.cpp
@@ -45,11 +45,6 @@ namespace PointMatcherSupport
 	timer::timer():
 		_start_time(curTime())
 	{
-	   #if defined(_POSIX_TIMERS) && !defined(FORCE_DISABLE_POSIX_TIMERS)
-	   std::cout << "Using POSIX timer\n";
-       #else
-       std::cout << "Using std::chrono timer\n";
-       #endif
 	}
 
 	void timer::restart()

--- a/pointmatcher/Timer.h
+++ b/pointmatcher/Timer.h
@@ -41,19 +41,22 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef WIN32
 #include <unistd.h>
 #endif // WIN32
+#if !defined(_POSIX_TIMERS) || defined(FORCE_DISABLE_POSIX_TIMERS)
+#include <chrono>
+#endif
 
-#if defined(_POSIX_TIMERS) && !defined(FORCE_DISABLE_POSIX_TIMERS)
+// #if defined(_POSIX_TIMERS) && !defined(FORCE_DISABLE_POSIX_TIMERS)
 namespace PointMatcherSupport
 {
 	/**
-		High-precision timer class, using clock_gettime() or clock_get_time()
+    	This is an interface between std::chrono::steady_clock and lpm
 
-		The interface is a subset of the one boost::timer provides,
-		but the implementation is much more precise
+    	Uses either std::chrono::steady_clock if _POSIX_TIMERS is not set, or
+		clock_gettime() or clock_get_time() if _POSIX_TIMERS is set,
+		generally in time.h or unistd.h. Then, the implementation is much more precise
 		on systems where clock() has low precision, such as glibc.
 
-		This code gets compiled if _POSIX_TIMERS is set,
-		generally in time.h or unistd.h
+		The interface is a subset of the original boost::timer class.
 	*/
 	struct timer
 	{
@@ -74,34 +77,5 @@ namespace PointMatcherSupport
 		Time _start_time; //! time when counter started
 	};
 } // namespace PointMatcherSupport
-#else // _POSIX_TIMERS
-#include <chrono>
-namespace PointMatcherSupport
-{
-
-    /**
-		This is an interface between std::chrono::steady_clock and lpm
-		This code gets compiled if _POSIX_TIMERS is not set
-	*/
-	struct timer
-	{
-		//! 64-bit time
-		typedef unsigned long long Time;
-
-		//! Create and start the timer
-		timer();
-		//! Restart the counter
-		void restart();
-		//! Return elapsed time in seconds
-		double elapsed() const;
-
-	private:
-		//! Return time at call
-		Time curTime() const;
-
-		Time _start_time; //! time when counter started
-	};
-}
-#endif // _POSIX_TIMERS
 
 #endif // __POINTMATCHER_TIMER_H

--- a/pointmatcher/Timer.h
+++ b/pointmatcher/Timer.h
@@ -36,21 +36,22 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef __POINTMATCHER_TIMER_H
 #define __POINTMATCHER_TIMER_H
 
+#include <iostream>
 #include <time.h>
 #ifndef WIN32
 #include <unistd.h>
 #endif // WIN32
 
-#ifdef _POSIX_TIMERS
+#if defined(_POSIX_TIMERS) && !defined(FORCE_DISABLE_POSIX_TIMERS)
 namespace PointMatcherSupport
 {
 	/**
 		High-precision timer class, using clock_gettime() or clock_get_time()
-		
+
 		The interface is a subset of the one boost::timer provides,
 		but the implementation is much more precise
 		on systems where clock() has low precision, such as glibc.
-		
+
 		This code gets compiled if _POSIX_TIMERS is set,
 		generally in time.h or unistd.h
 	*/
@@ -58,7 +59,7 @@ namespace PointMatcherSupport
 	{
 		//! 64-bit time
 		typedef unsigned long long Time;
-		
+
 		//! Create and start the timer
 		timer();
 		//! Restart the counter
@@ -69,15 +70,37 @@ namespace PointMatcherSupport
 	private:
 		//! Return time at call
 		Time curTime() const;
-		
+
 		Time _start_time; //! time when counter started
 	};
 } // namespace PointMatcherSupport
 #else // _POSIX_TIMERS
-#include <boost/timer.hpp>
+#include <chrono>
 namespace PointMatcherSupport
 {
-	typedef boost::timer timer;
+
+    /**
+		This is an interface between std::chrono::steady_clock and lpm
+		This code gets compiled if _POSIX_TIMERS is not set
+	*/
+	struct timer
+	{
+		//! 64-bit time
+		typedef unsigned long long Time;
+
+		//! Create and start the timer
+		timer();
+		//! Restart the counter
+		void restart();
+		//! Return elapsed time in seconds
+		double elapsed() const;
+
+	private:
+		//! Return time at call
+		Time curTime() const;
+
+		Time _start_time; //! time when counter started
+	};
 }
 #endif // _POSIX_TIMERS
 


### PR DESCRIPTION
# Description

### Summary:
This PR addresses #597 and the deprecation of `boost::timer` when not using POSIX timers.
It also adds a CMake variable `DISABLE_POSIX_TIMERS` to control whether the POSIX timers or `std::chrono::steady_clock` are used. Finally there is a simple example script showing how to use `PointMatcherSupport::timer` in code.
# Checklist:

### Code related

- [ ] I have made corresponding changes to the documentation 
      (i.e.: function, class, script header, README.md)
- [ ] I have commented hard-to-understand code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes 
      (Check [contributing_instructions.md](/doc/contributing/contributing_instructions.md) for local testing procedure using _libpointmatcher-build-system_)

### PR creation related

- [ ] My pull request `base ref` branch is set to the `develop` branch 
     (the _build-system_ won't be triggered otherwise)
- [ ] My pull request branch is up-to-date with the `develop` branch 
     (the _build-system_ will reject it otherwise)

### PR description related

- [ ] I have included a quick summary of the changes
- [ ] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`
- [ ] I have included a high-level list of changes and their corresponding types
      (See [commit_msg_reference.md](/doc/contributing/commit_msg_reference.md) for details)

---
